### PR TITLE
Build JVM bdk-ffi libs for macos m1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ repositories {
 dependencies {
   
   // for jvm
-  implementation 'org.bitcoindevkit:bdk-jvm:0.2.0'
+  implementation 'org.bitcoindevkit:bdk-jvm:0.3.0'
   // OR for android
-  implementation 'org.bitcoindevkit:bdk-android:0.2.0'
+  implementation 'org.bitcoindevkit:bdk-android:0.3.0'
   
 }
 
@@ -52,7 +52,7 @@ val newAddress = wallet.getNewAddress()
 
 * [tatooine](https://github.com/thunderbiscuit/tatooine)
 
-## How to build
+### How to build
 
 1. Clone this repository and init and update it's [`bdk-ffi`] submodule.
    ```shell
@@ -60,6 +60,10 @@ val newAddress = wallet.getNewAddress()
    git submodule update --init
    ```
 1. Follow the "General" bdk-ffi ["Getting Started (Developer)"] instructions.
+1. If building on MacOS install required intel and m1 jvm targets
+   ```sh
+   rustup target add x86_64-apple-darwin aarch64-apple-darwin
+   ```
 1. Install required targets
     ```sh
     rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android
@@ -75,6 +79,10 @@ val newAddress = wallet.getNewAddress()
     ```sh
     ./build.sh
     ```
+1. Start android emulator and run tests
+   ```sh
+   ./gradlew connectedAndroidTest 
+   ```
 
 ## How to publish
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ repositories {
 dependencies {
   
   // for jvm
-  implementation 'org.bitcoindevkit:bdk-jvm:0.3.1'
+  implementation 'org.bitcoindevkit:bdk-jvm:0.3.2'
   // OR for android
-  implementation 'org.bitcoindevkit:bdk-android:0.3.1'
+  implementation 'org.bitcoindevkit:bdk-android:0.3.2'
   
 }
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ repositories {
 dependencies {
   
   // for jvm
-  implementation 'org.bitcoindevkit:bdk-jvm:0.3.0'
+  implementation 'org.bitcoindevkit:bdk-jvm:0.3.1'
   // OR for android
-  implementation 'org.bitcoindevkit:bdk-android:0.3.0'
+  implementation 'org.bitcoindevkit:bdk-android:0.3.1'
   
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'org.bitcoindevkit'
                 artifactId = 'bdk-android'
-                version = '0.3.0'
+                version = '0.3.1'
 
                 pom {
                     name = 'bdk-android'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'org.bitcoindevkit'
                 artifactId = 'bdk-android'
-                version = '0.2.2'
+                version = '0.3.0'
 
                 pom {
                     name = 'bdk-android'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'org.bitcoindevkit'
                 artifactId = 'bdk-android'
-                version = '0.3.1'
+                version = '0.3.2'
 
                 pom {
                     name = 'bdk-android'

--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,8 @@ case $OS in
     cp target/x86_64-apple-darwin/release/libbdkffi.dylib ../jvm/src/main/resources/darwin-x86-64
     # aarch64 (m1)
     cargo build --release --target aarch64-apple-darwin
-    mkdir -p ../jvm/src/main/resources/darwin-arm64
-    cp target/aarch64-apple-darwin/release/libbdkffi.dylib ../jvm/src/main/resources/darwin-arm64
+    mkdir -p ../jvm/src/main/resources/darwin-aarch64
+    cp target/aarch64-apple-darwin/release/libbdkffi.dylib ../jvm/src/main/resources/darwin-aarch64
     ;;
   "Linux")
     echo -n "linux "

--- a/build.sh
+++ b/build.sh
@@ -4,20 +4,23 @@ set -eo pipefail
 echo "Build and test bdk-ffi library for local platform (darwin or linux)"
 pushd bdk-ffi
 
-cargo fmt
-cargo build --release
-cargo test
-
 OS=$(uname)
 echo -n "Copy "
 case $OS in
   "Darwin")
     echo -n "darwin "
+    # x86_64 (intel)
+    cargo build --release --target x86_64-apple-darwin
     mkdir -p ../jvm/src/main/resources/darwin-x86-64
-    cp target/release/libbdkffi.dylib ../jvm/src/main/resources/darwin-x86-64
+    cp target/x86_64-apple-darwin/release/libbdkffi.dylib ../jvm/src/main/resources/darwin-x86-64
+    # aarch64 (m1)
+    cargo build --release --target aarch64-apple-darwin
+    mkdir -p ../jvm/src/main/resources/darwin-arm64
+    cp target/aarch64-apple-darwin/release/libbdkffi.dylib ../jvm/src/main/resources/darwin-arm64
     ;;
   "Linux")
     echo -n "linux "
+    cargo build --release
     mkdir -p ../jvm/src/main/resources/linux-x86-64
     cp target/release/libbdkffi.so ../jvm/src/main/resources/linux-x86-64
     ;;

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -38,7 +38,7 @@ afterEvaluate {
 
                 groupId = 'org.bitcoindevkit'
                 artifactId = 'bdk-jvm'
-                version = '0.2.2'
+                version = '0.3.0'
 
                 pom {
                     name = 'bdk-jvm'

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -38,7 +38,7 @@ afterEvaluate {
 
                 groupId = 'org.bitcoindevkit'
                 artifactId = 'bdk-jvm'
-                version = '0.3.1'
+                version = '0.3.2'
 
                 pom {
                     name = 'bdk-jvm'

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -38,7 +38,7 @@ afterEvaluate {
 
                 groupId = 'org.bitcoindevkit'
                 artifactId = 'bdk-jvm'
-                version = '0.3.0'
+                version = '0.3.1'
 
                 pom {
                     name = 'bdk-jvm'


### PR DESCRIPTION
* Use latest version of `bdk-ffi`
* Update README and build.sh to build JVM bdk-ffi libs for macos intel (x86-64) and m1 (aarch64).
* Change version to 0.3.0