### PR TITLE
Remove compiler option for experimental unsigned types

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ val newAddress = wallet.getNewAddress()
 * [Tatooine Faucet](https://github.com/thunderbiscuit/tatooine)
 
 ### How to build
+_Note that Kotlin version `1.6.10` or later is required to build the library._
 
 1. Clone this repository and init and update it's [`bdk-ffi`] submodule.
    ```shell

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,4 @@ allprojects {
         google()
         mavenCentral()
     }
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.ExperimentalUnsignedTypes"
-    }
 }


### PR DESCRIPTION
### Description
This removes the compiler option to use experimental unsigned types, since they are not experimental anymore as of Kotlin 1.5. I have added a line in our readme specifying our use of Kotlin 1.6.10 or above for compilation of the library.

### Checklists
* [x] I've signed all my commits
