### PR TITLE
Add javadocs to jvm build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ repositories {
 dependencies {
   
   // for jvm
-  implementation 'org.bitcoindevkit:bdk-jvm:0.4.0'
+  implementation 'org.bitcoindevkit:bdk-jvm:<version>'
   // OR for android
-  implementation 'org.bitcoindevkit:bdk-android:0.4.0'
+  implementation 'org.bitcoindevkit:bdk-android:<version>'
   
 }
 ```

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -44,7 +44,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
-                version = "0.4.1-SNAPSHOT"
+                version = "0.6.0-SNAPSHOT"
                 from(components["release"])
                 pom {
                     name.set("bdk-android")

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -45,7 +45,7 @@ afterEvaluate {
 
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
-                version = "0.4.1-SNAPSHOT"
+                version = "0.6.0-SNAPSHOT"
 
                 from(components["java"])
 

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -12,6 +12,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     withSourcesJar()
+    withJavadocJar()
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
### Description

Fix publish by building javadocs for jvm on build.

### Notes to the reviewers

Also incrementing master branch version to `0.6.0-SNAPSHOT`. Also changed README to not have a hardcoded version.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

