### PR TITLE
Fix database memory test

### DIFF
--- a/android/src/androidTest/kotlin/org/bitcoindevkit/AndroidLibTest.kt
+++ b/android/src/androidTest/kotlin/org/bitcoindevkit/AndroidLibTest.kt
@@ -33,7 +33,7 @@ class AndroidLibTest {
     val descriptor =
         "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
 
-    val databaseConfig = DatabaseConfig.Memory("")
+    val databaseConfig = DatabaseConfig.Memory
     val blockchainConfig = BlockchainConfig.Electrum(
         ElectrumConfig(
             "ssl://electrum.blockstream.info:60002",
@@ -81,7 +81,6 @@ class AndroidLibTest {
 
     @Test
     fun onlineWalletInMemory() {
-        val database = DatabaseConfig.Memory("")
         val blockchain = BlockchainConfig.Electrum(
             ElectrumConfig(
                 "ssl://electrum.blockstream.info:60002",
@@ -91,7 +90,7 @@ class AndroidLibTest {
                 100u
             )
         )
-        val wallet = Wallet(descriptor, null, Network.TESTNET, database, blockchain)
+        val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig, blockchain)
         assertNotNull(wallet)
         val network = wallet.getNetwork()
         assertEquals(network, Network.TESTNET)


### PR DESCRIPTION
### Description
Fixes the Android tests that used the memory database config with the new API.

* [x] I've signed all my commits

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
