### PR TITLE
#32: Enable publishing bdk-android sources and java docs

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -23,6 +23,13 @@ android {
             proguardFiles(file("proguard-android-optimize.txt"), file("proguard-rules.pro"))
         }
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.1.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
     }
 }


### PR DESCRIPTION
### Description

Currently sources and javadocs are not being published for bdk-android artifact (unlike bdk-jvm) which makes it impossible to look up sources and documentation of bdk-android in IDE when using it in any project. AGP 7.1.0 added new APIs to `maven-publish` plugin to allow publishing sources and javadocs for Android super easy, which are being used here.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
