### PR TITLE
Update README and build.sh script to use latest env var naming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ _Note that Kotlin version `1.6.10` or later is required to build the library._
     ```
     See the [UniFFI User Guide](https://mozilla.github.io/uniffi-rs/) for more info
 1. Install Android SDK and Build-Tools for API level 30+
-1. Setup `$ANDROID_SDK_ROOT` and `$ANDROID_NDK_HOME` path variables (which are required by the 
+1. Setup `$ANDROID_SDK_ROOT` and `$ANDROID_NDK_ROOT` path variables (which are required by the 
    build scripts), for example (NDK major version 21 is required):
     ```shell
     export ANDROID_SDK_ROOT=~/Android/Sdk
-    export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/21.<NDK_VERSION>
+    export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/21.<NDK_VERSION>
     ```
 1. Build kotlin bindings
     ```sh

--- a/build.sh
+++ b/build.sh
@@ -32,11 +32,11 @@ uniffi-bindgen generate src/bdk.udl --no-format --out-dir ../jvm/src/main/kotlin
 
 ## android
 
-# If ANDROID_NDK_HOME is not set then set it to github actions default
-[ -z "$ANDROID_NDK_HOME" ] && export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+# If ANDROID_NDK_ROOT is not set then set it to github actions default
+[ -z "$ANDROID_NDK_ROOT" ] && export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk-bundle
 
 # Update this line accordingly if you are not building *from* darwin-x86_64 or linux-x86_64
-export PATH=$PATH:$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/`uname | tr '[:upper:]' '[:lower:]'`-x86_64/bin
+export PATH=$PATH:$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/`uname | tr '[:upper:]' '[:lower:]'`-x86_64/bin
 
 # Required for 'ring' dependency to cross-compile to Android platform, must be at least 21
 export CFLAGS="-D__ANDROID_API__=21"


### PR DESCRIPTION
### Description

`ANDROID_HOME`, `ANDROID_SDK_HOME`, and `ANDROID_NDK_HOME` are not used by the Android platform and SDK tools so these are considered deprecated/invalid.

Google recommends using `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` instead:
- https://groups.google.com/g/android-ndk/c/qZjhOaynHXc/m/2ux2ZZdxy2MJ
- https://developer.android.com/studio/command-line/variables

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing