### PR TITLE
Add CI steps to build bdk-ffi libraries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   build:
@@ -9,14 +9,38 @@ jobs:
       - name: Check out PR branch
         uses: actions/checkout@v2
 
+      - name: Update bdk-ffi git submodule
+        run: |
+          git submodule set-url bdk-ffi https://github.com/bitcoindevkit/bdk-ffi.git
+          git submodule update --init bdk-ffi
+
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           distribution: temurin
           java-version: 11
 
+      - name: Install rust android targets
+        run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android
+
+      - name: Install uniffi-bindgen
+        run: cargo install uniffi_bindgen --version 0.16.0
+
+      - name: Build bdk-ffi libraries
+        run: ./build.sh
+
       - name: Run Android tests
         run: ./gradlew :android:test --console=rich
 
       - name: Run JVM tests
         run: ./gradlew :jvm:test --console=rich
+


### PR DESCRIPTION
### Description

Added CI test steps to install and build the bdk-ffi libs that the kotlin tests depend on. 

### Notes to the reviewers

I also added caching, but it's still a bit slow. It's something to try and fix in a future PR. Another thing to do in the future is to start up an android emulator and run the android tests.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

