### PR TITLE
Add library version to API docs

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -100,6 +100,7 @@ tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
     dokkaSourceSets {
         named("main") {
             moduleName.set("bdk-android")
+            moduleVersion.set("0.6.0-SNAPSHOT")
             includes.from("Module.md")
         }
     }

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -96,6 +96,7 @@ tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
     dokkaSourceSets {
         named("main") {
             moduleName.set("bdk-jvm")
+            moduleVersion.set("0.6.0-SNAPSHOT")
             includes.from("Module.md")
         }
     }


### PR DESCRIPTION
### Description
This PR adds the version of the library to the Dokka docs. The final website looks like this:
<br>
![docs](https://user-images.githubusercontent.com/39974688/161308879-cf54b18f-c16d-4d5f-8a01-45dbfbe9094f.png)


### Notes to the reviewers
This PR fixes #42.

#### All Submissions:
* [x] I've signed all my commits