### PR TITLE
Fix dokka theme bug with AGP

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("kotlin-android")
     id("maven-publish")
     id("signing")
-    id("org.jetbrains.dokka") version "1.6.10"
+    id("org.jetbrains.dokka")
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     id("signing")
     id("maven-publish")
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("org.jetbrains.dokka") version "1.6.10"
 }
 
 signing {

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("java-library")
     id("maven-publish")
     id("signing")
-    id("org.jetbrains.dokka") version "1.6.10"
+    id("org.jetbrains.dokka")
 }
 
 java {


### PR DESCRIPTION
### Description
This PR fixes a regression introduced with the upgrade to Android Gradle Plugin `7.1.2`, where the Dokka theme applied to the API docs is an older version. I opened an issue on this and they were kind enough to look into it and provide a solution. See kotlin/dokka#2415

### Notes to the reviewers
This is the fix recommended by the Dokka team, which is to apply the Dokka plugin at the root of the project.

#### All Submissions:
* [x] I've signed all my commits

#### Bugfixes:
* [x] I'm linking the issue being fixed by this PR
