### PR TITLE
Create separate wallet for walletTxBuilderDrainWallet test

### DIFF
--- a/jvm/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
+++ b/jvm/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
@@ -149,29 +149,29 @@ class JvmLibTest {
         txBuilder.build(wallet)
     }
 
-      // Comment this test in for local testing, you will need let it fail ones to get an address
-      // to pre-fund the test wallet before the test will pass.
-//    @Test
-//    fun walletTxBuilderDrainWallet() {
-//        val descriptor =
-//            "wpkh([8da6afbe/84'/1'/0'/0]tprv8hY7jbMbe17EH1cLw2feTyNDYvjcFYauLmbneBqVnDERBrV51LrxWjCYRZwWS5keYn3ijb7iHJuEzXQk7EzgPeKRBVNBgC4oFPDxGND5S3V/*)"
-//        val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig, blockchainConfig)
-//        wallet.sync(LogProgress(), null)
-//        val balance = wallet.getBalance()
-//        if (balance > 2000u) {
-//            println("balance $balance")
-//            // send all coins back to https://bitcoinfaucet.uo1.net
-//            val faucetAddress = "tb1ql7w62elx9ucw4pj5lgw4l028hmuw80sndtntxt"
-//            val txBuilder = TxBuilder().drainWallet().drainTo(faucetAddress).feeRate(1.1f)
-//            val psbt = txBuilder.build(wallet)
-//            wallet.sign(psbt)
-//            val txid = wallet.broadcast(psbt)
-//            println("https://mempool.space/testnet/tx/$txid")
-//            assertNotNull(txid)
-//        } else {
-//            val depositAddress = wallet.getLastUnusedAddress()
-//            fail("Send more testnet coins to: $depositAddress")
-//        }
-//    }
+    // Comment this test in for local testing, you will need let it fail ones to get an address
+    // to pre-fund the test wallet before the test will pass.
+    // @Test
+    // fun walletTxBuilderDrainWallet() {
+    //     val descriptor =
+    //         "wpkh(tprv8ZgxMBicQKsPdLntKZchpr88aKr9Gkaxmi5EYGrgwW5imEGi3tCKYY9pEL5wnxcFHjGxM6cx6ySkgT4fCBDw1KvbFg99MWP6zCS3pz5WHzL/84h/1h/0h/0/*)"
+    //     val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig, blockchainConfig)
+    //     wallet.sync(LogProgress(), null)
+    //     val balance = wallet.getBalance()
+    //     if (balance > 2000u) {
+    //         println("balance $balance")
+    //         // send all coins back to https://bitcoinfaucet.uo1.net
+    //         val faucetAddress = "tb1ql7w62elx9ucw4pj5lgw4l028hmuw80sndtntxt"
+    //         val txBuilder = TxBuilder().drainWallet().drainTo(faucetAddress).feeRate(1.1f)
+    //         val psbt = txBuilder.build(wallet)
+    //         wallet.sign(psbt)
+    //         val txid = wallet.broadcast(psbt)
+    //         println("https://mempool.space/testnet/tx/$txid")
+    //         assertNotNull(txid)
+    //     } else {
+    //         val depositAddress = wallet.getLastUnusedAddress()
+    //         fail("Send more testnet coins to: $depositAddress")
+    //     }
+    // }
 
 }


### PR DESCRIPTION
This PR adds a different descriptor for the `walletTxBuilderDrainWallet` test, so as not to drain the main test wallet every time we run the test locally.