### PR TITLE
Build both x86_64 and aarch64 binaries when building bdk-jvm on macOS

### DIFF
--- a/buildSrc/src/main/kotlin/org/bitcoindevkit/plugins/Enums.kt
+++ b/buildSrc/src/main/kotlin/org/bitcoindevkit/plugins/Enums.kt
@@ -7,18 +7,6 @@ val operatingSystem: OS = when {
     else -> OS.OTHER
 }
 
-val architecture: Arch = when (System.getProperty("os.arch")) {
-    "x86_64" -> Arch.X86_64
-    "aarch64" -> Arch.AARCH64
-    else -> Arch.OTHER
-}
-
-enum class Arch {
-    AARCH64,
-    X86_64,
-    OTHER,
-}
-
 enum class OS {
     MAC,
     LINUX,


### PR DESCRIPTION
### Description
This PR changes the Gradle plugin to ensure both `x86_64` and `aarch64` versions of `bdk-jvm` get built whenever one calls the `buildJvmLib` command from macOS.

### Notes to the reviewers
This PR is still in draft mode because I need to test that the cross-compilation from an x86_64 mac works. In theory it should (it's one of the targets for the Rust compiler), but I have not tried it for myself yet.