### PR TITLE
feat: updated gitmodule to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bdk-ffi"]
 	path = bdk-ffi
-	url = git@github.com:bitcoindevkit/bdk-ffi.git
+	url = https://github.com/bitcoindevkit/bdk-ffi.git


### PR DESCRIPTION
### Description

Feat #59. Minor change to the `.gitmodule` folder url to use `HTTPS` instead of `SSH` to avoid SSH key authentication from Github.

### Notes to the reviewers

Users might have to call `git submodule sync --recursive` to sync the `.gitmodule` folder. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing