### PR TITLE
Bump bdk-ffi submodule to 0.7.0 and update tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+env:
+  ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -17,8 +17,6 @@ android {
     defaultConfig {
         minSdk = 21
         targetSdk = 31
-        // versionCode = 1
-        // versionName = "v0.2.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/android/src/androidTest/kotlin/org/bitcoindevkit/AndroidLibTest.kt
+++ b/android/src/androidTest/kotlin/org/bitcoindevkit/AndroidLibTest.kt
@@ -47,7 +47,7 @@ class AndroidLibTest {
     @Test
     fun memoryWalletNewAddress() {
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val address = wallet.getNewAddress()
+        val address = wallet.getAddress(AddressIndex.NEW).address
         assertNotNull(address)
         assertEquals("tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e", address)
     }
@@ -62,7 +62,7 @@ class AndroidLibTest {
         val testDataDir = getTestDataDir()
         val databaseConfig = DatabaseConfig.Sled(SledDbConfiguration(testDataDir, "testdb"))
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val address = wallet.getNewAddress()
+        val address = wallet.getAddress(AddressIndex.NEW).address
         assertNotNull(address)
         assertEquals("tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e", address)
         cleanupTestDataDir(testDataDir)
@@ -73,7 +73,7 @@ class AndroidLibTest {
         val testDataDir = getTestDataDir()+"/bdk-wallet.sqlite"
         val databaseConfig = DatabaseConfig.Sqlite(SqliteDbConfiguration(testDataDir))
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val blockchain = Blockchain(blockchainConfig);
+        val blockchain = Blockchain(blockchainConfig)
         wallet.sync(blockchain, LogProgress())
         val balance = wallet.getBalance()
         assertTrue(balance > 0u)
@@ -108,7 +108,7 @@ class AndroidLibTest {
     @Test
     fun onlineWalletSyncGetBalance() {
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val blockchain = Blockchain(blockchainConfig);
+        val blockchain = Blockchain(blockchainConfig)
         wallet.sync(blockchain, LogProgress())
         val balance = wallet.getBalance()
         assertTrue(balance > 0u)

--- a/jvm/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
+++ b/jvm/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
@@ -41,7 +41,7 @@ class JvmLibTest {
     @Test
     fun memoryWalletNewAddress() {
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val address = wallet.getNewAddress()
+        val address = wallet.getAddress(AddressIndex.NEW).address
         assertNotNull(address)
         assertEquals("tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e", address)
     }
@@ -56,7 +56,7 @@ class JvmLibTest {
         val testDataDir = getTestDataDir()
         val databaseConfig = DatabaseConfig.Sled(SledDbConfiguration(testDataDir, "testdb"))
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val address = wallet.getNewAddress()
+        val address = wallet.getAddress(AddressIndex.NEW).address
         assertNotNull(address)
         assertEquals("tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e", address)
         cleanupTestDataDir(testDataDir)
@@ -103,7 +103,7 @@ class JvmLibTest {
     @Test
     fun onlineWalletSyncGetBalance() {
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val blockchain = Blockchain(blockchainConfig);
+        val blockchain = Blockchain(blockchainConfig)
         wallet.sync(blockchain, LogProgress())
         val balance = wallet.getBalance()
         assertTrue(balance > 0u)
@@ -153,29 +153,28 @@ class JvmLibTest {
         txBuilder.finish(wallet)
     }
 
-      // Comment this test in for local testing, you will need let it fail ones to get an address
-      // to pre-fund the test wallet before the test will pass.
-//    @Test
-//    fun walletTxBuilderDrainWallet() {
-//        val descriptor =
-//            "wpkh([8da6afbe/84'/1'/0'/0]tprv8hY7jbMbe17EH1cLw2feTyNDYvjcFYauLmbneBqVnDERBrV51LrxWjCYRZwWS5keYn3ijb7iHJuEzXQk7EzgPeKRBVNBgC4oFPDxGND5S3V/*)"
-//        val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig, blockchainConfig)
-//        wallet.sync(LogProgress(), null)
-//        val balance = wallet.getBalance()
-//        if (balance > 2000u) {
-//            println("balance $balance")
-//            // send all coins back to https://bitcoinfaucet.uo1.net
-//            val faucetAddress = "tb1ql7w62elx9ucw4pj5lgw4l028hmuw80sndtntxt"
-//            val txBuilder = TxBuilder().drainWallet().drainTo(faucetAddress).feeRate(1.1f)
-//            val psbt = txBuilder.build(wallet)
-//            wallet.sign(psbt)
-//            val txid = wallet.broadcast(psbt)
-//            println("https://mempool.space/testnet/tx/$txid")
-//            assertNotNull(txid)
-//        } else {
-//            val depositAddress = wallet.getLastUnusedAddress()
-//            fail("Send more testnet coins to: $depositAddress")
-//        }
-//    }
-
+    // Comment this test in for local testing, you will need let it fail ones to get an address
+    // to pre-fund the test wallet before the test will pass.
+    // @Test
+    // fun walletTxBuilderDrainWallet() {
+    //     val descriptor = "wpkh([8da6afbe/84'/1'/0'/0]tprv8hY7jbMbe17EH1cLw2feTyNDYvjcFYauLmbneBqVnDERBrV51LrxWjCYRZwWS5keYn3ijb7iHJuEzXQk7EzgPeKRBVNBgC4oFPDxGND5S3V/*)"
+    //     val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
+    //     val blockchain = Blockchain(blockchainConfig)
+    //     wallet.sync(blockchain, LogProgress())
+    //     val balance = wallet.getBalance()
+    //     if (balance > 2000u) {
+    //         println("balance $balance")
+    //         // send all coins back to https://bitcoinfaucet.uo1.net
+    //         val faucetAddress = "tb1ql7w62elx9ucw4pj5lgw4l028hmuw80sndtntxt"
+    //         val txBuilder = TxBuilder().drainWallet().drainTo(faucetAddress).feeRate(1.1f)
+    //         val psbt = txBuilder.finish(wallet)
+    //         wallet.sign(psbt)
+    //         val txid = blockchain.broadcast(psbt)
+    //         println("https://mempool.space/testnet/tx/$txid")
+    //         assertNotNull(txid)
+    //     } else {
+    //         val depositAddress = wallet.getAddress(AddressIndex.LAST_UNUSED).address
+    //         fail("Send more testnet coins to: $depositAddress")
+    //     }
+    // }
 }


### PR DESCRIPTION
## Description
This PR is the migration to bdk-ffi `0.7.0`, and updates to the test suite.

## Notes to the reviewers
Both test suites have been upgraded.

## Checklist
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)