### PR TITLE
Remove old uniffi bindgen code in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,9 +35,6 @@ jobs:
       - name: Install rust android targets
         run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 
-      - name: Install uniffi-bindgen
-        run: cargo install uniffi_bindgen --version 0.16.0
-
       - name: Build bdk-android library
         run: ./gradlew :android:buildAndroidLib
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
           java-version: 11
 
       - name: Install rust android targets
-        run: rustup target add x86_64-linux-android aarch64-linux-android
+        run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 
       - name: Install uniffi-bindgen
         run: cargo install uniffi_bindgen --version 0.16.0


### PR DESCRIPTION
### Description
The CI was installing uniffi-bindgen, but that's not necessary now that we have the crate to do it internally.

### Notes to the reviewers

### Checklists

#### All Submissions:

* [x] I've signed all my commits
