### PR TITLE
Add workflow to publish bdk-jvm

### DIFF
--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -1,0 +1,102 @@
+name: Publish bdk-jvm to Maven Central
+on: [workflow_dispatch]
+#on:
+#  release:
+#    types: [published]
+
+jobs:
+  build-jvm-macOS-M1-native-lib:
+    name: Create M1 and x86_64 JVM native binaries
+    runs-on: macos-12
+    steps:
+      - name: Checkout publishing branch
+        uses: actions/checkout@v2
+
+      - name: Update bdk-ffi git submodule
+        run: |
+          git submodule set-url bdk-ffi https://github.com/bitcoindevkit/bdk-ffi.git
+          git submodule update --init bdk-ffi
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./bdk-ffi/target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Install aarch64 Rust target
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Build bdk-jvm library
+        run: ./gradlew :jvm:buildJvmLib
+
+      # build aarch64 + x86_64 native libraries and upload
+      - name: Upload macOS native libraries for reuse in publishing job
+        uses: actions/upload-artifact@v3
+        with:
+          # name: no name is required because we upload the entire directory
+          # the default name "artifact" will be used
+          path: /Users/runner/work/bdk-kotlin/bdk-kotlin/jvm/src/main/resources/
+
+  build-jvm-full-library:
+    name: Create full bdk-jvm library
+    needs: [build-jvm-macOS-M1-native-lib]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout publishing branch
+        uses: actions/checkout@v2
+
+      - name: Update bdk-ffi git submodule
+        run: |
+          git submodule set-url bdk-ffi https://github.com/bitcoindevkit/bdk-ffi.git
+          git submodule update --init bdk-ffi
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./bdk-ffi/target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Build bdk-jvm library
+        run: ./gradlew :jvm:buildJvmLib
+
+      - name: Download macOS native libraries from previous job
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          # download the artifact created in the prior job (named "artifact")
+          name: artifact
+          path: ./jvm/src/main/resources/
+
+      - name: Upload everything in jvm/src/
+        uses: actions/upload-artifact@v3
+        with:
+          name: final-src-directory
+          path: /home/runner/work/bdk-kotlin/bdk-kotlin/jvm/
+
+      - name: Publish to MavenLocal
+        run: ./gradlew :jvm:publishToMavenLocal --exclude-task signMavenPublication
+
+      # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
+      - name: Upload library from MavenLocal
+        uses: actions/upload-artifact@v3
+        with:
+          name: mavenlocal-bdk-jvm-artifact
+          path: ~/.m2/repository/

--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -1,0 +1,50 @@
+name: Test Android
+on: [push, pull_request]
+
+env:
+  ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
+  # By default the new ubuntu-20.04 images use the following ANDROID_NDK_ROOT
+  # ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/25.0.8775105
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Android NDK 21.4.7075529
+        run: |
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+
+      - name: Check out PR branch
+        uses: actions/checkout@v2
+
+      - name: Update bdk-ffi git submodule
+        run: |
+          git submodule set-url bdk-ffi https://github.com/bitcoindevkit/bdk-ffi.git
+          git submodule update --init bdk-ffi
+
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            bdk-ffi/target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Install rust android targets
+        run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
+
+      - name: Build bdk-android library
+        run: ./gradlew :android:buildAndroidLib
+
+      - name: Run Android tests
+        run: ./gradlew :android:test --console=rich

--- a/.github/workflows/test-jvm.yaml
+++ b/.github/workflows/test-jvm.yaml
@@ -1,23 +1,10 @@
-name: Tests
-
+name: Test JVM
 on: [push, pull_request]
-
-env:
-  ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
-  # By default the new ubuntu-20.04 images use the following ANDROID_NDK_ROOT
-  # ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/25.0.8775105
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Android NDK 21.4.7075529
-        run: |
-          ANDROID_ROOT=/usr/local/lib/android
-          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
-          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
-
       - name: Check out PR branch
         uses: actions/checkout@v2
 
@@ -40,15 +27,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Install rust android targets
-        run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
-
-      - name: Build bdk-android library
-        run: ./gradlew :android:buildAndroidLib
-
-      - name: Run Android tests
-        run: ./gradlew :android:test --console=rich
 
       - name: Build bdk-jvm library
         run: ./gradlew :jvm:buildJvmLib


### PR DESCRIPTION
## Description
This is the first draft at a workflow that will publish bdk-jvm and bdk-android to Maven Central

The workflow currently gets triggered manually and only offer the artifact that is published to MavenLocal for download. To trigger the workflow, go to `Actions -> Publish bdk-jvm to Maven Central -> Trigger workflow`

### Notes to the reviewers
Not ready for real publishing yet, but we need to merge something small first if we want to test and manually trigger the runs.
