### PR TITLE
Fix CI test workflow by using Android NDK 21

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,11 +4,20 @@ on: [push, pull_request]
 
 env:
   ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
+  # By default the new ubuntu-20.04 images use the following ANDROID_NDK_ROOT
+  # ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/25.0.8775105
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
+      - name: Install Android NDK 21.4.7075529
+        run: |
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+
       - name: Check out PR branch
         uses: actions/checkout@v2
 


### PR DESCRIPTION
## Description
This PR fixes our test CI workflow. The workflow stopped working on August 1st [when GitHub deprecated the Android NDK v21 in the Ubuntu CI images](https://github.com/actions/runner-images/issues/5930).

### Notes to the reviewers
This PR uses GitHub's proposed fix for installing the old NDK at runtime (see link above) because when I tried to simply migrate to the more recent v25 version we ran into compatibility issues with the Rust compilation steps. I think in the long run we should look into how we can migrate the NDK but for now this will work. I also pinned the version of Ubuntu the CI uses (`ubuntu-20.04`) instead of leaving it at `ubuntu-latest` (they're currently the same version but pinning it makes this versioning more explicit).

Note that we'll need to merge this before #72 and #76.