### PR TITLE
Sign bdk-jvm artifact in CI

### DIFF
--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -85,14 +85,18 @@ jobs:
           name: artifact
           path: ./jvm/src/main/resources/
 
-      - name: Upload everything in jvm/src/
-        uses: actions/upload-artifact@v3
-        with:
-          name: final-src-directory
-          path: /home/runner/work/bdk-kotlin/bdk-kotlin/jvm/
+      # - name: Upload everything in jvm/src/
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: final-src-directory
+      #     path: /home/runner/work/bdk-kotlin/bdk-kotlin/jvm/
 
       - name: Publish to MavenLocal
-        run: ./gradlew :jvm:publishToMavenLocal --exclude-task signMavenPublication
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_TEST_PASSPHRASE }}
+        # run: ./gradlew :jvm:publishToMavenLocal --exclude-task signMavenPublication
+        run: ./gradlew :jvm:publishToMavenLocal
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
       - name: Upload library from MavenLocal


### PR DESCRIPTION
This PR will allow signing of artifacts on the CI before uploading to Maven Central.

Notes: [Simpler and safer artifact signing on CI server with Gradle](https://blog.solidsoft.pl/2020/06/03/simpler-and-safer-artifact-signing-on-ci-server-with-gradle/)