### PR TITLE
Sign bdk-jvm artifact in CI

### DIFF
--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -85,14 +85,12 @@ jobs:
           name: artifact
           path: ./jvm/src/main/resources/
 
-      - name: Upload everything in jvm/src/
-        uses: actions/upload-artifact@v3
-        with:
-          name: final-src-directory
-          path: /home/runner/work/bdk-kotlin/bdk-kotlin/jvm/
-
       - name: Publish to MavenLocal
-        run: ./gradlew :jvm:publishToMavenLocal --exclude-task signMavenPublication
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+        run: ./gradlew :jvm:publishToMavenLocal
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
       - name: Upload library from MavenLocal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,12 +16,13 @@ plugins {
     id("org.jetbrains.dokka") version "1.6.10"
 }
 
-signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
-}
+// signing {
+//     val signingKeyId: String? by project
+//     val signingKey: String? by project
+//     val signingPassword: String? by project
+//     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+//     sign(publishing.publications)
+// }
 
 // does this need to be defined here? Not sure
 // it used to be defined in the nexusPublishing block but is not required

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -93,7 +93,10 @@ afterEvaluate {
 }
 
 signing {
-    useGpgCmd()
+    val signingKeyId: String? by project
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
 }
 


### PR DESCRIPTION
### Description
This allows us to sign the releases on the CI. One step further on the way to full publishing using the CI.

### Notes to the reviewers
This uses GitHub secrets, which I have confirmed do not get printed to logs.

#### All Submissions:
* [x] I've signed all my commits