### PR TITLE
Pick up Nexus credentials from GitHub secrets

### DIFF
--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -51,6 +51,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: ./gradlew :android:publishToMavenLocal :android:publishToSonatype
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -90,6 +90,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: ./gradlew :jvm:publishToMavenLocal :jvm:publishToSonatype
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/


### PR DESCRIPTION
This adds the ability for the CI to pull from GitHub secrets and use the credentials for Maven Central publishing.