### PR TITLE
Remove SNAPSHOT from artifact version

### DIFF
--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -48,7 +48,7 @@ afterEvaluate {
 
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
-                version = "0.9.0-SNAPSHOT"
+                version = "0.9.0"
 
                 from(components["java"])
 


### PR DESCRIPTION
The error we're getting in the CI publishing workflow is the following:
```shell
> Task :initializeSonatypeStagingRepository
Created staging repository 'orgbitcoindevkit-1110' at https://s01.oss.sonatype.org/service/local/repositories/orgbitcoindevkit-1110/content/


FAILURE: Build failed with an exception.

* What went wrong:
> Task :jvm:publishMavenPublicationToSonatypeRepository FAILED
Execution failed for task ':jvm:publishMavenPublicationToSonatypeRepository'.
> Failed to publish publication 'maven' to repository 'sonatype'
17 actionable tasks: 12 executed, 5 up-to-date
   > Could not PUT 'https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/orgbitcoindevkit-1110/org/bitcoindevkit/bdk-jvm/0.9.0-SNAPSHOT/maven-metadata.xml'. Received status code 400 from server: Bad Request

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org/

BUILD FAILED in 37s
Error: Process completed with exit code 1.
```

Given [this page](https://central.sonatype.org/faq/400-error/), I _think_ the issue is that we're uploading a `SNAPSHOT` version to a not-snapshot repository (snapshot versions go into their own special repositories).