### PR TITLE
Publish bdk-jvm and bdk-android on Maven Central

### DIFF
--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -53,11 +53,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
-        run: ./gradlew :android:publishToMavenLocal :android:publishToSonatype
-
-      # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
-      - name: Upload library from MavenLocal
-        uses: actions/upload-artifact@v3
-        with:
-          name: mavenlocal-bdk-android-artifact
-          path: ~/.m2/repository/
+        run: ./gradlew :android:publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -51,6 +51,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: ./gradlew :android:publishToMavenLocal :android:publishToSonatype
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/

--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -1,0 +1,61 @@
+name: Publish bdk-android to Maven Central
+on: [workflow_dispatch]
+
+env:
+  ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
+  # By default the new ubuntu-20.04 images use the following ANDROID_NDK_ROOT
+  # ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/25.0.8775105
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Android NDK 21.4.7075529
+        run: |
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+
+      - name: Check out PR branch
+        uses: actions/checkout@v2
+
+      - name: Update bdk-ffi git submodule
+        run: |
+          git submodule set-url bdk-ffi https://github.com/bitcoindevkit/bdk-ffi.git
+          git submodule update --init bdk-ffi
+
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            bdk-ffi/target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Install rust android targets
+        run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
+
+      - name: Build bdk-android library
+        run: ./gradlew :android:buildAndroidLib
+
+      - name: Publish to Maven Local and Maven Central
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+        run: ./gradlew :android:publishToMavenLocal :android:publishToSonatype
+
+      # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
+      - name: Upload library from MavenLocal
+        uses: actions/upload-artifact@v3
+        with:
+          name: mavenlocal-bdk-android-artifact
+          path: ~/.m2/repository/

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -85,18 +85,11 @@ jobs:
           name: artifact
           path: ./jvm/src/main/resources/
 
-      - name: Publish to Maven Local and Maven Central
+      - name: Publish to Maven Central
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
-        run: ./gradlew :jvm:publishToMavenLocal :jvm:publishToSonatype
-
-      # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
-      - name: Upload library from MavenLocal
-        uses: actions/upload-artifact@v3
-        with:
-          name: mavenlocal-bdk-jvm-artifact
-          path: ~/.m2/repository/
+        run: ./gradlew :jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -90,7 +90,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
-        run: ./gradlew :jvm:publishToMavenLocal
+        run: ./gradlew :jvm:publishToMavenLocal :jvm:publishToSonatype
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
       - name: Upload library from MavenLocal

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -85,7 +85,7 @@ jobs:
           name: artifact
           path: ./jvm/src/main/resources/
 
-      - name: Publish to MavenLocal
+      - name: Publish to Maven Local and Maven Central
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -85,14 +85,12 @@ jobs:
           name: artifact
           path: ./jvm/src/main/resources/
 
-      - name: Upload everything in jvm/src/
-        uses: actions/upload-artifact@v3
-        with:
-          name: final-src-directory
-          path: /home/runner/work/bdk-kotlin/bdk-kotlin/jvm/
-
       - name: Publish to MavenLocal
-        run: ./gradlew :jvm:publishToMavenLocal --exclude-task signMavenPublication
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+        run: ./gradlew :jvm:publishToMavenLocal
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/
       - name: Upload library from MavenLocal

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -90,6 +90,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: ./gradlew :jvm:publishToMavenLocal :jvm:publishToSonatype
 
       # Copy/paste this artifact in your local Maven repository at ~/.m2/repository/

--- a/android/Module.md
+++ b/android/Module.md
@@ -1,4 +1,0 @@
-# Module bdk-android
-The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Android.
-
-# Package org.bitcoindevkit

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -95,7 +95,12 @@ afterEvaluate {
 }
 
 signing {
-    useGpgCmd()
+    // useGpgCmd()
+    // sign(publishing.publications)
+    val signingKeyId: String? by project
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
     id("maven-publish")
     id("signing")
 
-    // API docs
-    id("org.jetbrains.dokka")
-
     // Custom plugin to generate the native libs and bindings file
     id("org.bitcoindevkit.plugins.generate-android-bindings")
 }
@@ -103,13 +100,3 @@ signing {
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
 }
-
-// tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
-//     dokkaSourceSets {
-//         named("main") {
-//             moduleName.set("bdk-android")
-//             moduleVersion.set("0.8.0-SNAPSHOT")
-//             includes.from("Module.md")
-//         }
-//     }
-// }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
     id("signing")
     id("maven-publish")
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    id("org.jetbrains.dokka") version "1.6.10"
 }
 
 // signing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,12 +16,13 @@ plugins {
     id("org.jetbrains.dokka") version "1.6.10"
 }
 
-signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
-}
+// signing {
+//     val signingKeyId: String? by project
+//     val signingKey: String? by project
+//     val signingPassword: String? by project
+//     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+//     sign(publishing.publications)
+// }
 
 // does this need to be defined here? Not sure
 // it used to be defined in the nexusPublishing block but is not required

--- a/jvm/Module.md
+++ b/jvm/Module.md
@@ -1,4 +1,0 @@
-# Module bdk-jvm
-The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for the JVM.
-
-# Package org.bitcoindevkit

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -93,7 +93,10 @@ afterEvaluate {
 }
 
 signing {
-    useGpgCmd()
+    val signingKeyId: String? by project
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
 }
 

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -7,9 +7,6 @@ plugins {
     id("maven-publish")
     id("signing")
 
-    // API docs
-    id("org.jetbrains.dokka")
-
     // Custom plugin to generate the native libs and bindings file
     id("org.bitcoindevkit.plugins.generate-jvm-bindings")
 }
@@ -99,13 +96,3 @@ signing {
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
 }
-
-// tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
-//     dokkaSourceSets {
-//         named("main") {
-//             moduleName.set("bdk-jvm")
-//             moduleVersion.set("0.8.0-SNAPSHOT")
-//             includes.from("Module.md")
-//         }
-//     }
-// }


### PR DESCRIPTION
### Description
This PR brings in the ability for the CI to publish the bdk-jvm and bdk-android libraries on the Maven Central _staging repository_. Once there we could publish them manually in the UI, or simply merge a further PR that will enable full publishing.

Notes:
1. These workflows can currently only be triggered manually by doing
```
Actions -> <workflow> -> Run workflow -> <branch>
```
2. These workflows will _only_ work with full release versions, i.e. you cannot trigger them with a SNAPSHOT version name (the Nexus repository will reject them).

### Checklists
#### All Submissions:
* [x] I've signed all my commits

#### New Features:
* [x] I've added docs for the new feature
