### PR TITLE
Bump SNAPSHOT version to 0.10.0-SNAPSHOT

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -52,7 +52,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
-                version = "0.9.0-SNAPSHOT"
+                version = "0.10.0-SNAPSHOT"
                 from(components["release"])
                 pom {
                     name.set("bdk-android")

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -48,7 +48,7 @@ afterEvaluate {
 
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
-                version = "0.9.0-SNAPSHOT"
+                version = "0.10.0-SNAPSHOT"
 
                 from(components["java"])
 


### PR DESCRIPTION
This PR bumps the snapshot version on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`.