### PR TITLE
Add option to build API docs into bdk-jvm website

### DIFF
--- a/api-docs/Module.md
+++ b/api-docs/Module.md
@@ -1,6 +1,0 @@
-# Module bdk-android
-The [bitcoindevkit](https://bitcoindevkit.org/) language bindings libraries for Android and the JVM.
-
-These docs are valid for both `bdk-jvm` and `bdk-android` libraries.
-
-# Package org.bitcoindevkit

--- a/api-docs/Module1.md
+++ b/api-docs/Module1.md
@@ -1,0 +1,4 @@
+# Module bdk-android
+The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Android.
+
+# Package org.bitcoindevkit

--- a/api-docs/Module2.md
+++ b/api-docs/Module2.md
@@ -1,0 +1,4 @@
+# Module bdk-jvm
+The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Kotlin and Java on the JVM.
+
+# Package org.bitcoindevkit

--- a/api-docs/build.gradle.kts
+++ b/api-docs/build.gradle.kts
@@ -28,8 +28,19 @@ tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
         named("main") {
             moduleName.set("bdk-android")
             moduleVersion.set("0.9.0")
-            includes.from("Module.md")
+            includes.from("Module1.md")
             samples.from("src/test/kotlin/org/bitcoindevkit/Samples.kt")
         }
     }
 }
+
+// tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
+//     dokkaSourceSets {
+//         named("main") {
+//             moduleName.set("bdk-jvm")
+//             moduleVersion.set("0.9.0")
+//             includes.from("Module2.md")
+//             samples.from("src/test/kotlin/org/bitcoindevkit/Samples.kt")
+//         }
+//     }
+// }

--- a/api-docs/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -172,7 +172,7 @@ data class TransactionDetails (
     var fee: ULong?,
     var received: ULong,
     var sent: ULong,
-    var txid: String
+    var txid: String,
     var confirmationTime: BlockTime?
 )
 


### PR DESCRIPTION
This PR adds a commented out section in the build script for the docs that can build the API docs website into its "bdk-jvm" counterpart.

The site content is identical to bdk-android but for the header and the home page.

### Notes to the reviewers
The way to build both websites it simply to comment out one or the other parts and call the `./gradlew dokkaHtml` task.

### Checklists
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)