### PR TITLE
Add group and version properties for nexus publishing plugin

### DIFF
--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -57,5 +57,4 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           cd bdk-android
-          ./gradlew publishToSonatype
-#          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -98,5 +98,4 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           cd bdk-jvm
-          ./gradlew publishToSonatype
-#          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -11,6 +11,13 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
+// These properties are required here so that the nexus publish-plugin
+// finds a staging profile with the correct group (group is otherwise set as "")
+// and knows whether to publish to a SNAPSHOT repository or not
+// https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
+group = "org.bitcoindevkit"
+version = "0.10.0"
+
 nexusPublishing {
     repositories {
         create("sonatype") {

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -58,6 +58,7 @@ afterEvaluate {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
                 version = "0.10.0-SNAPSHOT"
+
                 from(components["release"])
                 pom {
                     name.set("bdk-android")

--- a/bdk-jvm/build.gradle.kts
+++ b/bdk-jvm/build.gradle.kts
@@ -2,6 +2,13 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
+// These properties are required here so that the nexus publish-plugin
+// finds a staging profile with the correct group (group is otherwise set as "")
+// and knows whether to publish to a SNAPSHOT repository or not
+// https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
+group = "org.bitcoindevkit"
+version = "0.10.0"
+
 nexusPublishing {
     repositories {
         create("sonatype") {

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -49,13 +49,11 @@ afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("maven") {
-
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
                 version = "0.10.0-SNAPSHOT"
 
                 from(components["java"])
-
                 pom {
                     name.set("bdk-jvm")
                     description.set("Bitcoin Dev Kit Kotlin language bindings.")


### PR DESCRIPTION
This PR is a cherry-pick of 6c904cd26e6d994ab7e529856f580541d97a7a89 and 579c7cb07e2dc61a229d5f34ff775d680299d49b that adds the `group` and `version` properties to the root `build.gradle.kts` file. These properties are required for the nexus publish-plugin to work properly.

It also makes the default publishing workflow publish entirely instead of only to the staging repo.

Related to this PR is issue #101.