### PR TITLE
Bump versions to 0.11.0-SNAPSHOT

### DIFF
--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 // and knows whether to publish to a SNAPSHOT repository or not
 // https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
 group = "org.bitcoindevkit"
-version = "0.10.0"
+version = "0.11.0-SNAPSHOT"
 
 nexusPublishing {
     repositories {

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -57,7 +57,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
-                version = "0.10.0-SNAPSHOT"
+                version = "0.11.0-SNAPSHOT"
 
                 from(components["release"])
                 pom {

--- a/bdk-jvm/build.gradle.kts
+++ b/bdk-jvm/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 // and knows whether to publish to a SNAPSHOT repository or not
 // https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
 group = "org.bitcoindevkit"
-version = "0.10.0"
+version = "0.11.0-SNAPSHOT"
 
 nexusPublishing {
     repositories {

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -51,7 +51,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
-                version = "0.10.0-SNAPSHOT"
+                version = "0.11.0-SNAPSHOT"
 
                 from(components["java"])
                 pom {


### PR DESCRIPTION
This PR bumps the snapshot versions to `0.11.0-SNAPSHOT`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)