### PR TITLE
Bump ffi submodule to v0.11.0

### DIFF
--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -57,5 +57,4 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           cd bdk-android
-          ./gradlew publishToSonatype
-#          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -98,5 +98,4 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           cd bdk-jvm
-          ./gradlew publishToSonatype
-#          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -11,6 +11,13 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
+// These properties are required here so that the nexus publish-plugin
+// finds a staging profile with the correct group (group is otherwise set as "")
+// and knows whether to publish to a SNAPSHOT repository or not
+// https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
+group = "org.bitcoindevkit"
+version = "0.10.0"
+
 nexusPublishing {
     repositories {
         create("sonatype") {

--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 // and knows whether to publish to a SNAPSHOT repository or not
 // https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
 group = "org.bitcoindevkit"
-version = "0.10.0"
+version = "0.10.1"
 
 nexusPublishing {
     repositories {

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -57,7 +57,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
-                version = "0.10.0"
+                version = "0.10.1"
 
                 from(components["release"])
                 pom {

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -58,6 +58,7 @@ afterEvaluate {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
                 version = "0.10.0"
+
                 from(components["release"])
                 pom {
                     name.set("bdk-android")

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -57,7 +57,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
-                version = "0.10.0-SNAPSHOT"
+                version = "0.10.0"
                 from(components["release"])
                 pom {
                     name.set("bdk-android")

--- a/bdk-jvm/build.gradle.kts
+++ b/bdk-jvm/build.gradle.kts
@@ -2,6 +2,13 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
+// These properties are required here so that the nexus publish-plugin
+// finds a staging profile with the correct group (group is otherwise set as "")
+// and knows whether to publish to a SNAPSHOT repository or not
+// https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
+group = "org.bitcoindevkit"
+version = "0.10.0"
+
 nexusPublishing {
     repositories {
         create("sonatype") {

--- a/bdk-jvm/build.gradle.kts
+++ b/bdk-jvm/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 // and knows whether to publish to a SNAPSHOT repository or not
 // https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
 group = "org.bitcoindevkit"
-version = "0.10.0"
+version = "0.10.1"
 
 nexusPublishing {
     repositories {

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -52,7 +52,7 @@ afterEvaluate {
 
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
-                version = "0.10.0-SNAPSHOT"
+                version = "0.10.0"
 
                 from(components["java"])
 

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -51,7 +51,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
-                version = "0.10.0"
+                version = "0.10.1"
 
                 from(components["java"])
                 pom {

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -49,13 +49,11 @@ afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("maven") {
-
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
                 version = "0.10.0"
 
                 from(components["java"])
-
                 pom {
                     name.set("bdk-jvm")
                     description.set("Bitcoin Dev Kit Kotlin language bindings.")


### PR DESCRIPTION
This PR bumps the bdk-ffi submodule to `v0.11.0`.