### PR TITLE
Bump bdk-ffi submodule to v0.11.0

### DIFF
--- a/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
+++ b/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
@@ -22,7 +22,7 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
             workingDir("${projectDir}/../../bdk-ffi")
             val cargoArgs: MutableList<String> =
-                mutableListOf("build", "--release", "--target", "aarch64-linux-android")
+                mutableListOf("build", "--profile", "release-smaller", "--target", "aarch64-linux-android")
 
             executable("cargo")
             args(cargoArgs)
@@ -54,7 +54,7 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
             workingDir("${project.projectDir}/../../bdk-ffi")
             val cargoArgs: MutableList<String> =
-                mutableListOf("build", "--release", "--target", "x86_64-linux-android")
+                mutableListOf("build", "--profile", "release-smaller", "--target", "x86_64-linux-android")
 
             executable("cargo")
             args(cargoArgs)
@@ -86,7 +86,7 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
             workingDir("${project.projectDir}/../../bdk-ffi")
             val cargoArgs: MutableList<String> =
-                mutableListOf("build", "--release", "--target", "armv7-linux-androideabi")
+                mutableListOf("build", "--profile", "release-smaller", "--target", "armv7-linux-androideabi")
 
             executable("cargo")
             args(cargoArgs)
@@ -124,15 +124,15 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             into("${project.projectDir}/../lib/src/main/jniLibs/")
 
             into("arm64-v8a") {
-                from("${project.projectDir}/../../bdk-ffi/target/aarch64-linux-android/release/libbdkffi.so")
+                from("${project.projectDir}/../../bdk-ffi/target/aarch64-linux-android/release-smaller/libbdkffi.so")
             }
 
             into("x86_64") {
-                from("${project.projectDir}/../../bdk-ffi/target/x86_64-linux-android/release/libbdkffi.so")
+                from("${project.projectDir}/../../bdk-ffi/target/x86_64-linux-android/release-smaller/libbdkffi.so")
             }
 
             into("armeabi-v7a") {
-                from("${project.projectDir}/../../bdk-ffi/target/armv7-linux-androideabi/release/libbdkffi.so")
+                from("${project.projectDir}/../../bdk-ffi/target/armv7-linux-androideabi/release-smaller/libbdkffi.so")
             }
 
             doLast {

--- a/bdk-jvm/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiJvmPlugin.kt
+++ b/bdk-jvm/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiJvmPlugin.kt
@@ -18,20 +18,20 @@ internal class UniFfiJvmPlugin : Plugin<Project> {
                 exec {
                     workingDir("${project.projectDir}/../../bdk-ffi")
                     executable("cargo")
-                    val cargoArgs: List<String> = listOf("build", "--release", "--target", "x86_64-apple-darwin")
+                    val cargoArgs: List<String> = listOf("build", "--profile", "release-smaller", "--target", "x86_64-apple-darwin")
                     args(cargoArgs)
                 }
                 exec {
                     workingDir("${project.projectDir}/../../bdk-ffi")
                     executable("cargo")
-                    val cargoArgs: List<String> = listOf("build", "--release", "--target", "aarch64-apple-darwin")
+                    val cargoArgs: List<String> = listOf("build", "--profile", "release-smaller", "--target", "aarch64-apple-darwin")
                     args(cargoArgs)
                 }
             } else if(operatingSystem == OS.LINUX) {
                 exec {
                     workingDir("${project.projectDir}/../../bdk-ffi")
                     executable("cargo")
-                    val cargoArgs: List<String> = listOf("build", "--release", "--target", "x86_64-unknown-linux-gnu")
+                    val cargoArgs: List<String> = listOf("build", "--profile", "release-smaller", "--target", "x86_64-unknown-linux-gnu")
                     args(cargoArgs)
                 }
             }
@@ -76,7 +76,7 @@ internal class UniFfiJvmPlugin : Plugin<Project> {
                 doFirst {
                     copy {
                         with(it) {
-                            from("${project.projectDir}/../../bdk-ffi/target/${this.targetDir}/release/libbdkffi.${this.ext}")
+                            from("${project.projectDir}/../../bdk-ffi/target/${this.targetDir}/release-smaller/libbdkffi.${this.ext}")
                             into("${project.projectDir}/../../bdk-jvm/lib/src/main/resources/${this.resDir}/")
                         }
                     }


### PR DESCRIPTION
This PR bumps the submodule to the latest version, `v0.11.0`.